### PR TITLE
Use plugin_dir_url instead of magic url building to use relative type  according to the current page (http or https)

### DIFF
--- a/features/metaboxes/init.php
+++ b/features/metaboxes/init.php
@@ -81,16 +81,9 @@ class cmb_Meta_Box_Validate {
 
 /**
  * Defines the url to which is used to load local resources.
- * This may need to be filtered for local Window installations.
  * If resources do not load, please check the wiki for details.
  */
-if ( strtoupper( substr( PHP_OS, 0, 3 ) ) === 'WIN' ) {
-	//winblows
-	define( 'CMB_META_BOX_URL', trailingslashit( str_replace( DIRECTORY_SEPARATOR, '/', str_replace( str_replace( '/', DIRECTORY_SEPARATOR, WP_CONTENT_DIR ), WP_CONTENT_URL, dirname( __FILE__ ) ) ) ) );
-
-} else {
-	define( 'CMB_META_BOX_URL', apply_filters( 'cmb_meta_box_url', trailingslashit( str_replace( WP_CONTENT_DIR, WP_CONTENT_URL, dirname( __FILE__ ) ) ) ) );
-}
+ define ('CMB_META_BOX_URL', plugin_dir_url(__FILE__));
 
 /**
  * Create meta boxes


### PR DESCRIPTION
I am using the LENS theme from pixelgrade: http://themeforest.net/item/lens-an-enjoyable-photography-wordpress-theme/5713452.
I configured my wordpress instance to force SSL for the login and admin page.
The overall page does not use SSL (and I do not want it to!)

If wordpress is configured as described above, the gallery detail page fails to load: the gallery images do not show up. Google Chrome prints errors on the console "Mixed Content".
The broken page is: `wp-admin/post.php?post=121&action=edit`
I digged into the code and the fix I provide fixes the issue.
However I am not a php expert nor do I know anything about wordpress plugin development. 

This only works in combination with pull request https://github.com/pixelgrade/pixproof/pull/16 (The `pixproof` plugin also seems to lack the ability to serve resources correctly).

Please also note, that not all Mixed Content problems are gone.
I was only able to fix Errors, I still get warnings for each image in the gallery:
`Mixed Content: The page at 'https://example.com/wp-admin/post.php?post=42&action=edit' was loaded over HTTPS, but requested an insecure image 'http://example.com/wp-content/uploads/2014/11/image-300x225.jpg'. This content should also be served over HTTPS.`